### PR TITLE
Update link to POK3R user manual.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The following layers are used in either OS:
 * OSX: Layer 3 (red LED), switch with: `FN + .>`
 
 ## General POK3R programming info
-* [POK3R User Manual](files\POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
+* [POK3R User Manual](files/POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
 * Factory reset: Hold both the left and right `ALT` keys
 * Reset selected layer only: `FN + R` until LED under spacebar stops flashing
 


### PR DESCRIPTION
This link was broken for me. Switching to a forward slash took care of the issue. 

p.s. Thanks for the documentation repo - very useful.