### PR TITLE
Fix link to local copy of POK3R User Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The following layers are used in either OS:
 * OSX: Layer 3 (red LED), switch with: `FN + .>`
 
 ## General POK3R programming info
-* [POK3R User Manual](files\POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
+* [POK3R User Manual](files/POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
 * Factory reset: Hold both the left and right `ALT` keys
 * Reset selected layer only: `FN + R` until LED under spacebar stops flashing
 


### PR DESCRIPTION
I tried [this](https://github.com/blog/1395-relative-links-in-markup-files) but didn't work.  Seems like a forward slash fixes the issue.