### PR TITLE
Update Pok3r manual url for github clicks #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The following layers are used in either OS:
 * OSX: Layer 3 (red LED), switch with: `FN + .>`
 
 ## General POK3R programming info
-* [POK3R User Manual](files\POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
+* [POK3R User Manual](files/POK3R.User.Manual.V1.5.pdf); Vortex keeps shifting their URLs, so local copy (thanks @couto, @josephfusco)
 * Factory reset: Hold both the left and right `ALT` keys
 * Reset selected layer only: `FN + R` until LED under spacebar stops flashing
 


### PR DESCRIPTION
When clicking the url for the Pok3r manual, github resolves with a 404. The link currently has a backslash instead of a forward slash. This fixes #4.

* Change backslash in link to forward slash